### PR TITLE
allow value on submit inputs so the submit button label can be modified

### DIFF
--- a/propsify/standard/index.js
+++ b/propsify/standard/index.js
@@ -10,7 +10,7 @@ export default function propsify( attributes, slots, context ) {
   // In React, setting the value prop of an input element makes the element not
   // editable, and the defaultValue prop more closely matches the semantics of
   // the value attribute.
-  if (context.tagName === 'input' && props.defaultValue === undefined && props.value !== undefined ) {
+  if (context.tagName === 'input' && props.type !== 'submit' && props.defaultValue === undefined && props.value !== undefined ) {
     props.defaultValue = props.value;
     delete props.value;
   }


### PR DESCRIPTION
Without this, `<input type="submit" />` elements have their `value` attribute removed, and this results in every button having the text **submit** instead what they are configured to display.